### PR TITLE
Ignore .sass-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+.sass-cache/*


### PR DESCRIPTION
Why:

* We do not want to check-in Sass cache files

This PR:

* Adds `.sass-cache` to `.gitignore`