### PR TITLE
Remove need for element with id person_password inside input

### DIFF
--- a/src/jquery.password-validator.js
+++ b/src/jquery.password-validator.js
@@ -11,7 +11,7 @@
   // The actual plugin constructor
   function Plugin(element, options) {
     this.wrapperElement = element;
-    this.element = $(element).find("#person_password");
+    this.element = $(element);
     this.settings = $.extend({}, defaults, options);
     this._defaults = defaults;
     this._name = pluginName;


### PR DESCRIPTION
The documentation says to bind this to the input, but without this change the keyup and focus eventlistener only listen to events for a element called person_password inside the input.